### PR TITLE
Fix localClusterAuthEndpoint in cluster.yaml

### DIFF
--- a/charts/templates/cluster.yaml
+++ b/charts/templates/cluster.yaml
@@ -18,6 +18,12 @@ spec:
   {{- if .Values.kubernetesVersion }}
   kubernetesVersion: {{ .Values.kubernetesVersion }}
   {{- end }}
+  {{- if .Values.rke.localClusterAuthEndpoint.enabled }}
+  localClusterAuthEndpoint:
+    enabled: {{ .Values.rke.localClusterAuthEndpoint.enabled }}
+    fqdn: {{ .Values.rke.localClusterAuthEndpoint.fqdn }}
+    caCerts: {{ .Values.rke.localClusterAuthEndpoint.caCerts }}
+  {{- end }}
   # enable network policy
   enableNetworkPolicy: true
   # specify rancher helm chart values deployed into downstream cluster
@@ -164,12 +170,6 @@ spec:
         # cloud-provider-name: ""
         # Cloud provider configuration file path
         # cloud-provider-config: ""
-    {{- if .Values.rke.localClusterAuthEndpoint.enabled }}
-    localClusterAuthEndpoint:
-      enabled: {{ .Values.rke.localClusterAuthEndpoint.enabled }}
-      fqdn: {{ .Values.rke.localClusterAuthEndpoint.fqdn }}
-      caCerts: {{ .Values.rke.localClusterAuthEndpoint.caCerts }}
-    {{- end }}
     upgradeStrategy:
       controlPlaneDrainOptions:
         enabled: false


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/41242

## Change
The `localClusterAuthEndpoint` was in the wrong section of the rendered k8s manifest. It was being put under `spec.rkeConfig` when it should actually be directly under `spec`.

## Testing
I tested this manually by using Helm to create a new RKE2 cluster with the updated `cluster.yaml`. The result is that `localClusterAuthEndpoint` is populated correctly in the k8s manifest.
