### PR TITLE
Fix clusterrolestemplatebinding

### DIFF
--- a/charts/templates/clusterroletemplatebinding.yaml
+++ b/charts/templates/clusterroletemplatebinding.yaml
@@ -1,11 +1,15 @@
-{{ $root := . }}
-{{- range $index, $member := .Values.clusterMembers }}
+{{- $root := . }}
+{{- $fetchedcluster :=  (lookup "provisioning.cattle.io/v1" "Cluster" "fleet-default" .Values.cluster.name) }}
+{{- if ($fetchedcluster.status| default nil).clusterName | default nil }}
+  {{- range $index, $member := .Values.clusterMembers }}
+---
 apiVersion: management.cattle.io/v3
-clusterName: c-m-{{ trunc 8 (sha256sum (printf "%s/%s" $root.Release.Namespace $root.Values.cluster.name)) }}
+clusterName: {{ $fetchedcluster.status.clusterName }}
 kind: ClusterRoleTemplateBinding
 metadata:
-  name: ctrb-{{ trunc 8 (sha256sum (printf "%s/%s" $root.Release.Namespace $member.principalName )) }}
-  namespace: c-m-{{ trunc 8 (sha256sum (printf "%s/%s" $root.Release.Namespace $root.Values.cluster.name)) }}
+  name: ctrb-{{ trunc 8 (sha256sum (printf "%s/%s/%s" $root.Release.Namespace $member.principalName $member.roleTemplateName )) }}
+  namespace: {{ $fetchedcluster.status.clusterName }}
 roleTemplateName: {{ $member.roleTemplateName }}
 userPrincipalName: {{ $member.principalName }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
The clusterroletemplatebinding need the management cluster name which is generated in the source code of Rancher.
The lookup will directly fetch the management cluster name.

The if condition is to skip the creation on the first deployment of the App (rke2 cluster template) as the management cluster name and namespace are not created yet by Rancher.

Also adding $member.roleTemplateName to the name of ClusterRoleTemplateBinding to allow assignments of multiples roles to the same user.