### PR TITLE
Fix labels taints, aws

### DIFF
--- a/charts/templates/cluster.yaml
+++ b/charts/templates/cluster.yaml
@@ -57,6 +57,14 @@ spec:
         maxUnavailable: {{ $nodepool.rollingUpdate.maxUnavailable }}
         maxSurge: {{ $nodepool.rollingUpdate.maxSurge }}
       {{- end }}
+      {{- if $nodepool.labels }}
+      labels:
+{{ toYaml $nodepool.labels | indent 8 }}
+      {{- end }}
+      {{- if $nodepool.taints }}
+      taints:
+{{ toYaml $nodepool.taints | indent 8 }}
+      {{- end }}
       {{- if $nodepool.machineDeploymentLabels }}
       machineDeploymentLabels:
 {{ toYaml $nodepool.machineDeploymentLabels | indent 8 }}
@@ -93,6 +101,14 @@ spec:
       rollingUpdate:
         maxUnavailable: {{ $nodepool.rollingUpdate.maxUnavailable }}
         maxSurge: {{ $nodepool.rollingUpdate.maxSurge }}
+      {{- end }}
+      {{- if $nodepool.labels }}
+      labels:
+{{ toYaml $nodepool.labels | indent 8 }}
+      {{- end }}
+      {{- if $nodepool.taints }}
+      taints:
+{{ toYaml $nodepool.taints | indent 8 }}
       {{- end }}
       {{- if $nodepool.machineDeploymentLabels }}
       machineDeploymentLabels:

--- a/charts/templates/nodeconfig-aws.yaml
+++ b/charts/templates/nodeconfig-aws.yaml
@@ -14,15 +14,6 @@ blockDurationMinutes: {{ $nodepool.blockDurationMinutes }}
 {{- if $nodepool.deviceName }}
 deviceName: {{ $nodepool.deviceName }}
 {{- end }}
-common:
-{{- if $nodepool.labels }}
-  labels:
-{{ toYaml $nodepool.labels | indent 4 }}
-{{- end }}
-{{- if $nodepool.taints }}
-  taints:
-{{ toYaml $nodepool.taints | indent 4 }}
-{{- end }}
 {{- if $nodepool.encryptEbsVolume }}
 encryptEbsVolume: {{ $nodepool.encryptEbsVolume }}
 {{- end }}
@@ -127,15 +118,6 @@ blockDurationMinutes: {{ $nodepool.blockDurationMinutes }}
 {{- end }}
 {{- if $nodepool.deviceName }}
 deviceName: {{ $nodepool.deviceName }}
-{{- end }}
-common:
-{{- if $nodepool.labels }}
-  labels:
-{{ toYaml $nodepool.labels | indent 4 }}
-{{- end }}
-{{- if $nodepool.taints }}
-  taints:
-{{ toYaml $nodepool.taints | indent 4 }}
 {{- end }}
 {{- if $nodepool.encryptEbsVolume }}
 encryptEbsVolume: {{ $nodepool.encryptEbsVolume }}


### PR DESCRIPTION
common in Amazonec2Config doesn't exist
Maybe the same for all others provider but I didn't test so I only removed from the Amazonec2Config.

Adding the taints and labels into the Cluster.provisioning.cattle.io/v1 resources, in machinePools.